### PR TITLE
Fix Repository error in case of empty sort order

### DIFF
--- a/templates/crud/Model/ResourceModel/Repository.template
+++ b/templates/crud/Model/ResourceModel/Repository.template
@@ -196,6 +196,9 @@ class %class% implements %interface%
         $sortOrders = $searchCriteria->getSortOrders();
         if ($sortOrders) {
             foreach ($sortOrders as $sortOrder) {
+                if (empty($sortOrder->getData())) {
+                    continue;
+                }
                 $isAscending = $sortOrder->getDirection() == \Magento\Framework\Api\SortOrder::SORT_ASC;
                 $collection->addOrder($sortOrder->getField(), $isAscending ? 'ASC' : 'DESC');
             }


### PR DESCRIPTION
Calling `getList()` on a repository created by codemonkey like this:
```
$repository->getList($this->searchCriteriaBuilder->create())
```
will result in a SQL error:
```
SQLSTATE[42000]: Syntax error or access violation: 1064 You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'DESC' at line 1, query was: SELECT `main_table`.* FROM `some_table` AS `main_table` ORDER BY  DESC
```
becouse of `ORDER BY  DESC`